### PR TITLE
Fix broken linkedin link

### DIFF
--- a/_includes/team/kei.html
+++ b/_includes/team/kei.html
@@ -4,7 +4,7 @@
   <footer>
     <a href="skype:kei.ellerbrock"><img class="skype" src="/images/sprite-blank.gif" alt="Skype" title="Skype" width="16" height="16"></a>
     <a href="mailto:kei@smartlogic.io"><img class="email" src="/images/sprite-blank.gif" alt="Email" title="Email" width="16" height="16"></a>
-    <a href="www.linkedin.com/pub/kathryn-ellerbrock/68/436/871"><img class="linked-in" src="/images/sprite-blank.gif" alt="Linked-In" title="Linked-In" width="16" height="16"></a>
+    <a href="https://www.linkedin.com/pub/kathryn-ellerbrock/68/436/871"><img class="linked-in" src="/images/sprite-blank.gif" alt="Linked-In" title="Linked-In" width="16" height="16"></a>
     <a href="http://github.com/KeiEllerbrock"><img class="github" src="/images/sprite-blank.gif" alt="GitHub" title="GitHub" width="16" height="16"></a>
   </footer>
 </figure>


### PR DESCRIPTION
Trolling your site, noticed the new member and the broken link!

Changes link from relative to absolute. Untested (doing this all on GitHub), but it should do the trick.
