### PR TITLE
fix doctype declaration

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,4 +1,4 @@
-<DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8">


### PR DESCRIPTION
@yflicker this is how the doctype should be declared, browsers seem to be handling it ok but still.
