### PR TITLE
Add mouseflow tracking to layout

### DIFF
--- a/_includes/ga-tracking-script.html
+++ b/_includes/ga-tracking-script.html
@@ -1,0 +1,8 @@
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  ga('create', 'UA-466947-1', 'auto');
+  ga('send', 'pageview');
+</script>

--- a/_includes/hubspot-tracking-script.html
+++ b/_includes/hubspot-tracking-script.html
@@ -1,0 +1,8 @@
+<script type="text/javascript">
+  (function(d,s,i,r) {
+    if (d.getElementById(i)){return;}
+    var n=d.createElement(s),e=d.getElementsByTagName(s)[0];
+    n.id=i;n.src='//js.hs-analytics.net/analytics/'+(Math.ceil(new Date()/r)*r)+'/451063.js';
+    e.parentNode.insertBefore(n, e);
+  })(document,"script","hs-analytics",300000);
+</script>

--- a/_includes/mouseflow-tracking-script.html
+++ b/_includes/mouseflow-tracking-script.html
@@ -1,0 +1,8 @@
+<script type="text/javascript">
+  var _mfq = _mfq || [];
+  (function () {
+    var mf = document.createElement("script"); mf.type = "text/javascript"; mf.async = true;
+    mf.src = "//cdn.mouseflow.com/projects/f772f1a9-a985-4ff9-b78e-4d94fa5f10d2.js";
+    document.getElementsByTagName("head")[0].appendChild(mf);
+  })();
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -61,21 +61,8 @@
       {{ content }}
     </div>
 
-    <script type="text/javascript">
-      (function(d,s,i,r) {
-        if (d.getElementById(i)){return;}
-        var n=d.createElement(s),e=d.getElementsByTagName(s)[0];
-        n.id=i;n.src='//js.hs-analytics.net/analytics/'+(Math.ceil(new Date()/r)*r)+'/451063.js';
-        e.parentNode.insertBefore(n, e);
-      })(document,"script","hs-analytics",300000);
-    </script>
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-466947-1', 'auto');
-      ga('send', 'pageview');
-    </script>
+    {% include hubspot-tracking-script.html %}
+    {% include ga-tracking-script.html %}
+    {% include mouseflow-tracking-script.html %}    
   </body>
 </html>


### PR DESCRIPTION
Before this commit our marketing site had two types of tracking, google
analytics and hubspot.

In this commit, two changes have been made:
1) I’ve added mouseflow tracking to do some click / mouse hover data
tracking
2) now that we have more than 2 included script tags, I’ve separated
the script tags into partials.

This refactor intends to make our layout a little cleaner, and also
name the include tags so future developers will know which tags are
tracking what.