### PR TITLE
Added bot language to Experience page

### DIFF
--- a/experience.html
+++ b/experience.html
@@ -83,5 +83,8 @@ root-navigation: experience
     <li class="cloud">
       <h2>Cloud Deployments</h2>
       <p>We identify the most appropriate hosting environment for your application. We've used AWS (Amazon), Heroku, Digital Ocean, Rackspace and many others.</p>
+    <li class="team">
+      <h2>Bots</h2>
+      <p>Chatbots: We help you engage with your users where they are using the latest natural language chatbot technology.</p>
   </ul>
 </article>


### PR DESCRIPTION
This commit adds a sentence to our Experience page about bots. The iconography used in conjunction with the bots blurb is the existing "strong robot" used on the Get in Touch page (hence the class="team" style).