### PR TITLE
add typeform, swap out for google form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -28,7 +28,8 @@ description: ""
       <div class="contact__left">
         <div class="contact__left-form-wrap">
           <form class="contact__left-form">
-            <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSdeprE4CsiERvdUCHjP6vlMVtjcKLsYlEIL0EdmcXl4fws_qg/viewform?embedded=true" width="100%" height="1155" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
+            <div class="typeform-widget" data-url="https://smartlogicmarketing.typeform.com/to/j4QvMJ" style="width: 100%; height: 500px;"></div> <script> (function() { var qs,js,q,s,d=document, gi=d.getElementById, ce=d.createElement, gt=d.getElementsByTagName, id="typef_orm", b="https://embed.typeform.com/"; if(!gi.call(d,id)) { js=ce.call(d,"script"); js.id=id; js.src=b+"embed.js"; q=gt.call(d,"script")[0]; q.parentNode.insertBefore(js,q) } })() </script> <div style="font-family: Sans-Serif;font-size: 12px;color: #999;opacity: 0.5; padding-top: 5px;"> powered by <a href="https://admin.typeform.com/signup?utm_campaign=j4QvMJ&utm_source=typeform.com-13714231-Basic&utm_medium=typeform&utm_content=typeform-embedded-poweredbytypeform&utm_term=EN" style="color: #999" target="_blank">Typeform</a> </div>
+            <!-- <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSdeprE4CsiERvdUCHjP6vlMVtjcKLsYlEIL0EdmcXl4fws_qg/viewform?embedded=true" width="100%" height="1155" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe> -->
             <!-- <div class="form__row">
               <div class="form__col-6 form__col">
                 <label for="formName">Name<span>*</span></label>


### PR DESCRIPTION
@yflicker @danivovich swapped typeform in, I think it's a cleaner look and was super easy to set up and link to a google sheet and slack. It is branded and we're limited to 100 form fills / month on the free plan but I think it's a more polished look than the google form