### PR TITLE
Replace YT Embed Link

### DIFF
--- a/podcast/elixir-wizards/index.html
+++ b/podcast/elixir-wizards/index.html
@@ -38,7 +38,7 @@ include_rss: true
     <section class="section content-block podcast">
       <p><em> Watch our latest episode:</em></p>
       <div class="podcast-video-container">
-        <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=brYYnn_-jh8-wJfz&amp;list=PLTDLmInI9YaDLibZpATyyjMyoc8NWKhHk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+        <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=nqBH-_dLzS5-jv_h&amp;list=PLTDLmInI9YaDj9-geiITkziMrTlBKWncs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
       </div>
 
       <br/>


### PR DESCRIPTION
Replace the link for YT watch latest episode on main Elixir Wizards page.