### PR TITLE
Match video container to video aspect ratio

### DIFF
--- a/_sass/pages/podcast.scss
+++ b/_sass/pages/podcast.scss
@@ -193,7 +193,7 @@
 }
 .podcast-video-container, .podcast-audio-container {
   height: 0;
-  padding-bottom: 56.25%;
+  padding-bottom: 53.25%;
   padding-top: 30px;
   position: relative;
   overflow: hidden;


### PR DESCRIPTION
This reduces bottom-padding on the video container because it was taller than the video's aspect ratio, and that was causing the sides to get cut off.