### PR TITLE
Update to v3 of Fireside podcast embed

### DIFF
--- a/_sass/pages/podcast.scss
+++ b/_sass/pages/podcast.scss
@@ -191,7 +191,7 @@
     text-align: center;
   }
 }
-.podcast-video-container, .podcast-audio-container {
+.podcast-video-container {
   height: 0;
   padding-bottom: 53.25%;
   padding-top: 30px;
@@ -207,8 +207,8 @@
   }
 }
 .podcast-audio-container {
-  padding-bottom: 25.6%;
-  padding-top: 5vw;
+  padding: 10px 0 15px;
+  width: 100%;
 }
 // The fireside embed aspect ratio is non-constant
 @media screen and (max-width: 445px) {

--- a/podcast/elixir-wizards/index.html
+++ b/podcast/elixir-wizards/index.html
@@ -46,7 +46,7 @@ include_rss: true
       <p><em> Listen to our latest episode:</em></p>
 
       <div class="podcast-audio-container">
-        <iframe style="margin-bottom:20px" src="https://player.fireside.fm/v2/IAs5ixts/latest?theme=light" width="960" height="200" frameborder="0" scrolling="no"></iframe>
+        <iframe style="border-radius: 0;" src="https://player.fireside.fm/v3/IAs5ixts/latest?theme=light&background=efefef&accent=000000" width="100%" height="200" frameborder="0" scrolling="no"></iframe>
       </div>
 
       <p>Elixir Wizards is an interview-format podcast, focused on engineers who use the Elixir programming language.


### PR DESCRIPTION
The Fireside embed we were using was their v2, which was no longer supported and was no longer showing the latest episode. This PR updates to their v3. Unfortunately, their setting for no border-radius isn't working so the embed now has rounded corners. We can probably open a ticket with Fireside to get this fixed. [Their tool](https://app.fireside.fm/podcasts/smartlogic/player) has a setting for border-radius, it just doesn't work for the no radius setting.

I also adjusted corresponding CSS to keep it mobile responsive and generally looking like the previous version.